### PR TITLE
Refactor: Rename BlazeWrapper to Blaze4j

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(blaze_wrapper)
+project(blaze4j)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 20)
@@ -27,23 +27,23 @@ endif()
 add_subdirectory("${PROJECT_SOURCE_DIR}/deps/blaze")
 
 # Create the shared library
-add_library(blaze_wrapper SHARED
+add_library(blaze4j SHARED
     src/main/cpp/blaze_wrapper.cpp)
 
 # No need to redefine BLAZE_EXPORT here; the macro is set in the source file with proper platform guards.
 
 # Disable strcpy deprecation warning for MSVC
 if(MSVC)
-    target_compile_definitions(blaze_wrapper PRIVATE _CRT_SECURE_NO_WARNINGS)
+    target_compile_definitions(blaze4j PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
 # Link against blaze libraries
-target_link_libraries(blaze_wrapper
+target_link_libraries(blaze4j
     PUBLIC
     sourcemeta::blaze::compiler
     sourcemeta::blaze::evaluator)
 
 # Include directories
-target_include_directories(blaze_wrapper
+target_include_directories(blaze4j
     PUBLIC
     ${PROJECT_SOURCE_DIR}/src/main/cpp)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.sourcemeta</groupId>
-    <artifactId>blaze-wrapper</artifactId>
+    <artifactId>blaze4j</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>

--- a/src/main/cpp/blaze_wrapper.cpp
+++ b/src/main/cpp/blaze_wrapper.cpp
@@ -62,43 +62,43 @@ BLAZE_EXPORT int64_t blaze_compile(const char* schema, const char* walker, const
 
             auto resolver_obj = [](std::string_view uri_sv) -> std::optional<sourcemeta::core::JSON> {
                 std::string uri(uri_sv);
-                std::cerr << "[DEBUG blaze_wrapper] Resolver: Attempting to resolve URI: " << uri << std::endl;
+                std::cerr << "[DEBUG blaze4j] Resolver: Attempting to resolve URI: " << uri << std::endl;
 
                 auto official_result = sourcemeta::core::schema_official_resolver(uri_sv);
                 if (official_result.has_value()) {
-                    std::cerr << "[DEBUG blaze_wrapper] Resolver: Found in built-in resolver for URI: " << uri << std::endl;
+                    std::cerr << "[DEBUG blaze4j] Resolver: Found in built-in resolver for URI: " << uri << std::endl;
                     return official_result;
                 }
 
-                std::cerr << "[DEBUG blaze_wrapper] Resolver: Not found in built-in resolver for URI: " << uri << std::endl;
+                std::cerr << "[DEBUG blaze4j] Resolver: Not found in built-in resolver for URI: " << uri << std::endl;
 
                 if (current_custom_resolver != nullptr) {
-                    std::cerr << "[DEBUG blaze_wrapper] Resolver: Attempting custom resolver for URI: " << uri << std::endl;
+                    std::cerr << "[DEBUG blaze4j] Resolver: Attempting custom resolver for URI: " << uri << std::endl;
                     const char* result_c_str = current_custom_resolver(uri.c_str());
 
                     if (result_c_str != nullptr) {
                         std::string result_str(result_c_str);
                         try {
-                            std::cerr << "[DEBUG blaze_wrapper] Resolver: Retrieved custom schema (first 100 chars): " 
+                            std::cerr << "[DEBUG blaze4j] Resolver: Retrieved custom schema (first 100 chars): " 
                                       << result_str.substr(0, 100) << (result_str.length() > 100 ? "..." : "") << std::endl;
                             auto parsed_json = sourcemeta::core::parse_json(result_str);
                             return parsed_json;
                         } catch (const std::exception& e) {
-                            std::cerr << "[ERROR blaze_wrapper] Error parsing JSON from custom resolver: " << e.what() << std::endl;
+                            std::cerr << "[ERROR blaze4j] Error parsing JSON from custom resolver: " << e.what() << std::endl;
                         }
                     } else {
-                        std::cerr << "[DEBUG blaze_wrapper] Custom resolver returned NULL for URI: " << uri << std::endl;
+                        std::cerr << "[DEBUG blaze4j] Custom resolver returned NULL for URI: " << uri << std::endl;
                     }
                 }
 
-                std::cerr << "[DEBUG blaze_wrapper] Resolver: Returning nullopt for URI: " << uri << std::endl;
+                std::cerr << "[DEBUG blaze4j] Resolver: Returning nullopt for URI: " << uri << std::endl;
                 return std::nullopt;
             };
 
             std::cerr << "Creating compiler instance" << std::endl;
             auto compiler = sourcemeta::blaze::default_schema_compiler;
 
-            std::cerr << "[DEBUG blaze_wrapper] Calling sourcemeta::blaze::compile..." << std::endl;
+            std::cerr << "[DEBUG blaze4j] Calling sourcemeta::blaze::compile..." << std::endl;
             auto compiled = sourcemeta::blaze::compile(
                 json_schema,
                 walker_obj,
@@ -107,7 +107,7 @@ BLAZE_EXPORT int64_t blaze_compile(const char* schema, const char* walker, const
                 sourcemeta::blaze::Mode::FastValidation,
                 dialect_opt
             );
-            std::cerr << "[DEBUG blaze_wrapper] Compilation successful." << std::endl;
+            std::cerr << "[DEBUG blaze4j] Compilation successful." << std::endl;
 
             current_custom_resolver = nullptr;
 

--- a/src/main/java/com/sourcemeta/blaze/BlazeWrapper.java
+++ b/src/main/java/com/sourcemeta/blaze/BlazeWrapper.java
@@ -30,7 +30,7 @@ class BlazeWrapper {
     static {
         try {
             // Try to load the library using its base name first
-            System.loadLibrary("blaze_wrapper");
+            System.loadLibrary("blaze4j");
         } catch (UnsatisfiedLinkError e) {
             // If that fails, try platform-specific paths
             String osName = System.getProperty("os.name").toLowerCase();
@@ -39,17 +39,17 @@ class BlazeWrapper {
             
             if (osName.contains("win")) {
                 // Windows path
-                libPath = userDir + "/build/bin/Release/blaze_wrapper.dll";
+                libPath = userDir + "/build/bin/Release/blaze4j.dll";
             } else if (osName.contains("mac")) {
                 // Mac path
-                libPath = userDir + "/build-mac/bin/blaze_wrapper.dylib";
+                libPath = userDir + "/build-mac/bin/blaze4j.dylib";
             } else {
                 // Linux/WSL path
-                libPath = userDir + "/build-linux/lib/libblaze_wrapper.so";
+                libPath = userDir + "/build-linux/lib/libblaze4j.so";
                 
                 // Check if file exists, if not try alternative location
                 if (!new File(libPath).exists()) {
-                    libPath = userDir + "/build/libblaze_wrapper.so";
+                    libPath = userDir + "/build/libblaze4j.so";
                 }
             }
             


### PR DESCRIPTION


### 📌 Summary

This PR renames the project from **`BlazeWrapper` to `Blaze4j`** across the core configuration and source files to ensure consistency and alignment with the new project branding.

 PR Close #3 

### ✅ Changes Made

#### 1. Maven Configuration (`pom.xml`)
- Changed `artifactId` from `blaze-wrapper` to `blaze4j`.

#### 2. CMake Configuration (`CMakeLists.txt`)
- Updated project name from `blaze_wrapper` to `blaze4j`.
- Updated all references in CMake variables and targets.
- Renamed library targets from `blaze_wrapper` to `blaze4j`.

#### 3. Native Library Loading (`BlazeWrapper.java`)
- Updated library loading path from `blaze_wrapper` to `blaze4j`.
- Changed all platform-specific library file names:
  - Windows: `blaze_wrapper.dll` → `blaze4j.dll`
  - Linux: `libblaze_wrapper.so` → `libblaze4j.so`
  - macOS: `blaze_wrapper.dylib` → `blaze4j.dylib`

#### 4. Native Code (`blaze_wrapper.cpp`)
- Updated all debug print statements from `"blaze_wrapper"` to `"blaze4j"`.

---

### 🚫 Excluded from This PR
- No changes made to `README.md`. Documentation updates will be handled in a separate PR.

