### PR TITLE
Release v0.0.2: Migrate to Java 22 with stable FFM API

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,10 +21,10 @@ jobs:
         git clone --depth 1 https://github.com/sourcemeta/blaze.git deps/blaze
         git clone --depth 1 https://github.com/json-schema-org/JSON-Schema-Test-Suite.git src/test/resources/JSON-Schema-Test-Suite
 
-    - name: Set up JDK 21
+    - name: Set up JDK 22
       uses: actions/setup-java@v3
       with:
-        java-version: '21'
+        java-version: '22'
         distribution: 'temurin'
         cache: maven
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,10 +21,10 @@ jobs:
         git clone --depth 1 https://github.com/sourcemeta/blaze.git deps/blaze
         git clone --depth 1 https://github.com/json-schema-org/JSON-Schema-Test-Suite.git src/test/resources/JSON-Schema-Test-Suite
 
-    - name: Set up JDK 21
+    - name: Set up JDK 22
       uses: actions/setup-java@v3
       with:
-        java-version: '21'
+        java-version: '22'
         distribution: 'temurin'
         cache: maven
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,10 +22,10 @@ jobs:
         git clone --depth 1 https://github.com/sourcemeta/blaze.git deps/blaze
         git clone --depth 1 https://github.com/json-schema-org/JSON-Schema-Test-Suite.git src/test/resources/JSON-Schema-Test-Suite
 
-    - name: Set up JDK 21
+    - name: Set up JDK 22
       uses: actions/setup-java@v3
       with:
-        java-version: '21'
+        java-version: '22'
         distribution: 'temurin'
         cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
 
   <groupId>io.github.madhavdhatrak</groupId>
   <artifactId>blaze4j</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.2</version>
 
   <name>Blaze4j</name>
-  <description>A Java wrapper for the Sourcemeta Blaze JSON Schema validator using FFM</description>
+  <description>A Java wrapper for the Sourcemeta Blaze JSON Schema validator using stable FFM API (Java 22+)</description>
   <url>https://github.com/madhavdhatrak/blaze4j</url>
   <licenses>
     <license>
@@ -33,8 +33,8 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>22</maven.compiler.source>
+    <maven.compiler.target>22</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -79,7 +79,6 @@
         <version>3.11.0</version>
         <configuration>
           <compilerArgs>
-            <arg>--enable-preview</arg>
           </compilerArgs>
         </configuration>
       </plugin>
@@ -111,7 +110,6 @@
         <configuration>
           <doclint>none</doclint>
           <additionalJOptions>
-            <additionalJOption>--enable-preview</additionalJOption>
           </additionalJOptions>
         </configuration>
       </plugin>
@@ -138,13 +136,13 @@
                 </configuration>
             </plugin>
             
-            <!-- Unit tests with preview features enabled -->
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
                 <configuration>
-                    <argLine>--enable-preview --enable-native-access=ALL-UNNAMED</argLine>
+                    <argLine>--enable-native-access=ALL-UNNAMED</argLine>
                     <useSystemClassLoader>true</useSystemClassLoader>
                 </configuration>
             </plugin>


### PR DESCRIPTION
##  Release v0.0.2: Java 22 Migration

This PR migrates Blaze4j to Java 22 with the newly stable Foreign Function & Memory (FFM) API, removing all preview dependencies and ensuring long-term compatibility.

### ✨ What's New
- **Java 22 Requirement**: Now requires JDK 22+ (no longer supports Java 21)
- **Stable FFM API**: Uses the finalized FFM API without any preview flags
- **Updated CI**: All workflows (Linux, macOS, Windows) now use JDK 22
- **Version Bump**: Updated to v0.0.2

### 🔧 Technical Changes

#### FFM API Migration
- ✅ Replaced `arena.allocateUtf8String()` → `arena.allocateFrom()`
- ✅ Replaced `segment.getUtf8String()` → custom `getNullTerminatedUtf8String()` helper
- ✅ Removed all `--enable-preview` flags from build configuration

#### Build & CI Updates
- ✅ Updated `pom.xml` compiler source/target: `21` → `22`
- ✅ Removed preview flags from compiler, javadoc, and test plugins
- ✅ Updated GitHub Actions workflows to use JDK 22
- ✅ Kept `--enable-native-access=ALL-UNNAMED` (required for FFM native calls)

#### Project Metadata
- ✅ Version bump: `0.0.1` → `0.0.2`
- ✅ Updated description to mention Java 22+ requirement
